### PR TITLE
Fix pointless defaultWorld setting

### DIFF
--- a/Bukkit/src/net/tnemc/core/Reserve.java
+++ b/Bukkit/src/net/tnemc/core/Reserve.java
@@ -61,11 +61,7 @@ public class Reserve extends JavaPlugin {
     if(!ConfigurationManager.loadSettings()) {
       // Failed to load configuration. You decide what to do.
     }
-    if(Bukkit.getWorlds().size() >= 1) {
-      defaultWorld = Bukkit.getServer().getWorlds().get(0).getName();
-    } else {
-      defaultWorld = "world";
-    }
+    defaultWorld = Bukkit.getServer().getWorlds().get(0).getName();
     registerCommand(new String[]{"reserve", "rsv"}, new ReserveCommand(this));
 
     new Metrics(this, 2586);


### PR DESCRIPTION
The current implementation is both problematic and doesn't make sense.

First of all: Unless the server disabled end and nether generation will the `getWorlds()` list never be less than 2 and I doubt that any server only has 1 single world, as even lobby server benefit from multiple ones for easier player distribution.

Next could you simply just get the first entry all the time. Even IF there was only one entry in the list would the list have 1 entry so `get(0)` would always work.

Finally, making `defaultWorld` default to `"world"` is stupid. Not every server uses `world` as the default level name, so this would essentially break on servers with just 1 world and that just happens to not use `"world"` as their default level name.

I honestly have to ask why you guys made this random setup... It's pointless, ugly and doesn't give any real benefit.